### PR TITLE
Remove Node 18.x from test matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18.x, 20.x, 22.x]
+        node-version: [20.x, 22.x]
       fail-fast: false
 
     steps:


### PR DESCRIPTION
Updated the GitHub Actions test workflow to remove Node 18.x testing. The workflow now only tests on Node 20.x and 22.x.

All other jobs (lint-check, dependency-audit, test-summary) remain unchanged.