### PR TITLE
fix: remove duplicate county from county aria-label (#81)

### DIFF
--- a/src/modules/interactions.js
+++ b/src/modules/interactions.js
@@ -1760,7 +1760,7 @@ export function initEnhancedMapInteractions() {
             'rockingham': 'Rockingham County'
         };
         const countyName = countyDisplayNames[countyKey] || countyKey;
-        county.setAttribute('aria-label', `View ${countyName} county recommendations`);
+        county.setAttribute('aria-label', `View ${countyName} recommendations`);
     });
 }
 


### PR DESCRIPTION
## Fix

**Issue:** #81

`countyName` is already in the form "Grafton County", so the aria-label was showing "View Grafton County county recommendations" — the word "county" appeared twice.

**Change:** Line 1763 in src/modules/interactions.js
- Before: `View ${countyName} county recommendations`
- After: `View ${countyName} recommendations`

This gives correct aria-labels like "View Grafton County recommendations".